### PR TITLE
refactor: loose redirect uri requirements

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    if: ${{ github.repository == 'panva/node-oidc-provider' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'logto-io/node-oidc-provider' || github.event_name == 'workflow_dispatch' }}
     uses: panva/.github/.github/workflows/build-conformance-suite.yml@main
 
   run:

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   lock:
-    if: ${{ github.repository == 'panva/node-oidc-provider' }}
+    if: ${{ github.repository == 'logto-io/node-oidc-provider' }}
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   npm:
-    if: ${{ github.repository == 'panva/node-oidc-provider' }}
+    if: ${{ github.repository == 'logto-io/node-oidc-provider' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   audit:
-    if: ${{ github.repository == 'panva/node-oidc-provider' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'logto-io/node-oidc-provider' || github.event_name == 'workflow_dispatch' }}
     uses: panva/.github/.github/workflows/npm-audit.yml@main
 
   node-versions:
@@ -20,7 +20,7 @@ jobs:
       min: 18
 
   test:
-    if: ${{ github.repository == 'panva/node-oidc-provider' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'logto-io/node-oidc-provider' || github.event_name == 'workflow_dispatch' }}
     needs:
       - node-versions
     name: Test Suite

--- a/lib/helpers/client_schema.js
+++ b/lib/helpers/client_schema.js
@@ -531,10 +531,18 @@ export default function getSchema(provider) {
 
         switch (this.application_type) { // eslint-disable-line default-case
           case 'web': {
-            if (!['https:', 'http:'].includes(protocol)) {
-              this.invalidate(`${label} must only contain web uris`);
-            }
+            // We commented out the following checks because in the real world, these checks often
+            // cause frustration for developers who are coping with the legacy apps that don't
+            // follow the best practices. We'll explicitly warn about these issues in the Console.
+            // Keep the code here for upstream reference.
+            //
+            // if (!['https:', 'http:'].includes(protocol)) {
+            //   this.invalidate(`${label} must only contain web uris`);
+            // }
 
+            // In Logto, the following checks have no effect because we don't support the implicit
+            // flow.
+            //
             if (this.grant_types.includes('implicit')) {
               if (protocol === 'http:') {
                 this.invalidate(`${label} for web clients using implicit flow MUST only register URLs using the https scheme`, 'implicit-force-https');
@@ -547,22 +555,27 @@ export default function getSchema(provider) {
             break;
           }
           case 'native': {
-            switch (protocol) {
-              case 'http:': // Loopback Interface Redirection
-                if (!LOOPBACKS.has(hostname)) {
-                  this.invalidate(`${label} for native clients using http as a protocol can only use loopback addresses as hostnames`);
-                }
-                break;
-              case 'https:': // Claimed HTTPS URI Redirection
-                if (LOOPBACKS.has(hostname)) {
-                  this.invalidate(`${label} for native clients using claimed HTTPS URIs must not be using ${hostname} as hostname`);
-                }
-                break;
-              default: // Private-use URI Scheme Redirection
-                if (!protocol.includes('.')) {
-                  this.invalidate(`${label} for native clients using Custom URI scheme should use reverse domain name based scheme`);
-                }
-            }
+            // We commented out the following checks because in the real world, these checks often
+            // cause frustration for developers who are coping with the legacy apps that don't
+            // follow the best practices. We'll explicitly warn about these issues in the Console.
+            // Keep the code here for upstream reference.
+            //
+            // switch (protocol) {
+            //   case 'http:': // Loopback Interface Redirection
+            //     if (!LOOPBACKS.has(hostname)) {
+            //       this.invalidate(`${label} for native clients using http as a protocol can only use loopback addresses as hostnames`);
+            //     }
+            //     break;
+            //   case 'https:': // Claimed HTTPS URI Redirection
+            //     if (LOOPBACKS.has(hostname)) {
+            //       this.invalidate(`${label} for native clients using claimed HTTPS URIs must not be using ${hostname} as hostname`);
+            //     }
+            //     break;
+            //   default: // Private-use URI Scheme Redirection
+            //     if (!protocol.includes('.')) {
+            //       this.invalidate(`${label} for native clients using Custom URI scheme should use reverse domain name based scheme`);
+            //     }
+            // }
             break;
           }
         }

--- a/test/configuration/client_metadata.test.js
+++ b/test/configuration/client_metadata.test.js
@@ -463,10 +463,12 @@ describe('Client metadata validation', () => {
         application_type: 'web',
       },
     );
-    rejects(this.title, ['no-dot-reverse-notation:/some'], undefined, {
+    // Updated test to reflect the forked version of oidc-provider
+    allows(this.title, ['no-dot-reverse-notation:/some'], undefined, {
       application_type: 'web',
     });
-    rejects(this.title, ['https://localhost'], undefined, {
+    // Updated test to reflect the forked version of oidc-provider
+    allows(this.title, ['https://localhost'], undefined, {
       application_type: 'web',
       grant_types: ['implicit', 'authorization_code'],
       response_types: ['code id_token'],
@@ -474,13 +476,15 @@ describe('Client metadata validation', () => {
     allows(this.title, ['http://localhost'], {
       application_type: 'web',
     });
-    rejects(this.title, ['http://some'], undefined, {
+    // Updated test to reflect the forked version of oidc-provider
+    allows(this.title, ['http://some'], undefined, {
       application_type: 'native',
     });
     rejects(this.title, ['not-a-uri'], undefined, {
       application_type: 'native',
     });
-    rejects(this.title, ['http://foo/bar'], undefined, {
+    // Updated test to reflect the forked version of oidc-provider
+    allows(this.title, ['http://foo/bar'], undefined, {
       application_type: 'web',
       grant_types: ['implicit'],
       response_types: ['id_token'],
@@ -553,10 +557,12 @@ describe('Client metadata validation', () => {
         application_type: 'web',
       },
     );
-    rejects(this.title, ['no-dot-reverse-notation:/some'], undefined, {
+    // Updated test to reflect the forked version of oidc-provider
+    allows(this.title, ['no-dot-reverse-notation:/some'], undefined, {
       application_type: 'web',
     });
-    rejects(this.title, ['https://localhost'], undefined, {
+    // Updated test to reflect the forked version of oidc-provider
+    allows(this.title, ['https://localhost'], undefined, {
       application_type: 'web',
       grant_types: ['implicit', 'authorization_code'],
       response_types: ['code id_token'],
@@ -564,13 +570,15 @@ describe('Client metadata validation', () => {
     allows(this.title, ['http://localhost'], {
       application_type: 'web',
     });
-    rejects(this.title, ['http://some'], undefined, {
+    // Updated test to reflect the forked version of oidc-provider
+    allows(this.title, ['http://some'], undefined, {
       application_type: 'native',
     });
     rejects(this.title, ['not-a-uri'], undefined, {
       application_type: 'native',
     });
-    rejects(this.title, ['http://foo/bar'], undefined, {
+    // Updated test to reflect the forked version of oidc-provider
+    allows(this.title, ['http://foo/bar'], undefined, {
       application_type: 'web',
       grant_types: ['implicit'],
       response_types: ['id_token'],

--- a/test/oauth_native_apps/oauth_native_apps.test.js
+++ b/test/oauth_native_apps/oauth_native_apps.test.js
@@ -20,18 +20,15 @@ describe('OAuth 2.0 for Native Apps Best Current Practice features', () => {
         });
       });
 
-      it('rejects custom schemes without dots with reverse domain name scheme recommendation', function () {
-        return assert.rejects(i(this.provider).clientAdd({
+      // Updated test to reflect the forked version of oidc-provider
+      it('allows custom schemes without dots with reverse domain name scheme recommendation', function () {
+        return i(this.provider).clientAdd({
           application_type: 'native',
           client_id: 'native-custom',
           grant_types: ['implicit'],
           response_types: ['id_token'],
           token_endpoint_auth_method: 'none',
           redirect_uris: ['myapp:/op/callback'],
-        }), (err) => {
-          expect(err).to.have.property('message', 'invalid_redirect_uri');
-          expect(err).to.have.property('error_description', 'redirect_uris for native clients using Custom URI scheme should use reverse domain name based scheme');
-          return true;
         });
       });
     });
@@ -48,18 +45,15 @@ describe('OAuth 2.0 for Native Apps Best Current Practice features', () => {
         });
       });
 
-      it('rejects https if using loopback uris', function () {
-        return assert.rejects(i(this.provider).clientAdd({
+      // Updated test to reflect the forked version of oidc-provider
+      it('allows https if using loopback uris', function () {
+        return i(this.provider).clientAdd({
           application_type: 'native',
           client_id: 'native-custom',
           grant_types: ['implicit'],
           response_types: ['id_token'],
           token_endpoint_auth_method: 'none',
           redirect_uris: ['https://localhost/op/callback'],
-        }), (err) => {
-          expect(err).to.have.property('message', 'invalid_redirect_uri');
-          expect(err).to.have.property('error_description', 'redirect_uris for native clients using claimed HTTPS URIs must not be using localhost as hostname');
-          return true;
         });
       });
     });
@@ -188,18 +182,20 @@ describe('OAuth 2.0 for Native Apps Best Current Practice features', () => {
         });
       });
 
-      it('rejects http protocol uris not using loopback uris', function () {
-        return assert.rejects(i(this.provider).clientAdd({
+      // Updated test to reflect the forked version of oidc-provider
+      it('allows http protocol uris not using loopback uris', function () {
+        return i(this.provider).clientAdd({
           application_type: 'native',
           client_id: 'native-custom',
           grant_types: ['implicit'],
           response_types: ['id_token'],
           token_endpoint_auth_method: 'none',
           redirect_uris: ['http://rp.example.com/op/callback'],
-        }), (err) => {
-          expect(err).to.have.property('message', 'invalid_redirect_uri');
-          expect(err).to.have.property('error_description', 'redirect_uris for native clients using http as a protocol can only use loopback addresses as hostnames');
-          return true;
+        }).then((client) => {
+          expect(client.redirectUris).to.contain('http://rp.example.com/op/callback');
+          expect(client.redirectUriAllowed('http://rp.example.com/op/callback')).to.be.true;
+          expect(client.redirectUriAllowed('http://rp.example.com:80/op/callback')).to.be.true;
+          expect(client.redirectUriAllowed('http://rp.example.com:443/op/callback')).to.be.false;
         });
       });
     });


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
loose redirect uri enforcements to allow:

1. mix up of native and http(s) redirect uris
2. native schemes without a `.`

we understand these are not best practices, however, in the real world, there are things we cannot control, like a third-party service or operation systems like Windows.

this pull loose those requirements, and we'll add explicit warnings in Console accordingly.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
updated test cases accordingly
