### PR TITLE
feat: support wildcard patterns in redirect URIs

### DIFF
--- a/lib/actions/authorization/one_redirect_uri_clients.js
+++ b/lib/actions/authorization/one_redirect_uri_clients.js
@@ -11,7 +11,12 @@ export default function oneRedirectUriClients(ctx, next) {
 
   const { params, client } = ctx.oidc;
 
-  if (params.redirect_uri === undefined && client.redirectUris.length === 1) {
+  if (
+    params.redirect_uri === undefined
+    && client.redirectUris.length === 1
+    // Wildcard redirect URIs must always be explicitly provided.
+    && !client.redirectUris[0].includes('*')
+  ) {
     ctx.oidc.redirectUriCheckPerformed = true;
     [params.redirect_uri] = client.redirectUris;
   }

--- a/lib/actions/authorization/one_redirect_uri_clients.js
+++ b/lib/actions/authorization/one_redirect_uri_clients.js
@@ -11,11 +11,13 @@ export default function oneRedirectUriClients(ctx, next) {
 
   const { params, client } = ctx.oidc;
 
+  const allowWildcards = instance(ctx.oidc.provider).configuration('allowWildcardRedirectUris');
+
   if (
     params.redirect_uri === undefined
     && client.redirectUris.length === 1
     // Wildcard redirect URIs must always be explicitly provided.
-    && !client.redirectUris[0].includes('*')
+    && !(allowWildcards && client.redirectUris[0].includes('*'))
   ) {
     ctx.oidc.redirectUriCheckPerformed = true;
     [params.redirect_uri] = client.redirectUris;

--- a/lib/helpers/client_schema.js
+++ b/lib/helpers/client_schema.js
@@ -515,14 +515,27 @@ export default function getSchema(provider) {
     }
 
     redirectUris(uris = this.redirect_uris, label = 'redirect_uris') {
+      const allowWildcards = configuration.allowWildcardRedirectUris;
+
       uris.forEach((redirectUri) => {
         let hostname;
         let protocol;
         let hash;
+
+        const hasWildcard = redirectUri.includes('*');
+        // When wildcards are enabled, replace '*' with 'wildcard' for URL parsing
+        const uriToParse = allowWildcards && hasWildcard
+          ? redirectUri.replace(/\*/g, 'wildcard')
+          : redirectUri;
+
         try {
-          ({ hostname, protocol, hash } = new URL(redirectUri));
+          ({ hostname, protocol, hash } = new URL(uriToParse));
         } catch (err) {
           this.invalidate(`${label} must only contain valid uris`);
+        }
+
+        if (hasWildcard && !allowWildcards) {
+          this.invalidate(`${label} must not contain wildcards unless allowWildcardRedirectUris is enabled`);
         }
 
         if (hash) {

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -797,8 +797,9 @@ function makeDefaults() {
      * title: Allow wildcard patterns in redirect URIs.
      *
      * description: When enabled, redirect URIs can contain wildcard patterns (using `*`) in the
-     * hostname and pathname. Wildcards are not allowed in scheme, port, query, or hash. When
-     * wildcards are used in hostname, at least one dot is required to prevent overly broad patterns.
+     * hostname and pathname. Wildcards are not allowed in scheme, port, query, hash, or top-level
+     * domain positions. When wildcards are used in hostname, at least one dot is required and the
+     * last two hostname labels must not contain wildcards to prevent overly broad patterns.
      *
      * example: Valid wildcard patterns
      * ```js
@@ -811,6 +812,9 @@ function makeDefaults() {
      * '*://example.com/callback'        // scheme
      * 'https://example.com:*/callback'  // port
      * 'https://example.com?code=*'      // query
+     * 'https://example.com/callback#*'  // hash
+     * 'https://*.com/callback'          // top-level domain
+     * 'https://example.*/callback'      // top-level domain
      * ```
      */
     allowWildcardRedirectUris: false,

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -792,6 +792,30 @@ function makeDefaults() {
     allowOmittingSingleRegisteredRedirectUri: true,
 
     /*
+     * allowWildcardRedirectUris
+     *
+     * title: Allow wildcard patterns in redirect URIs.
+     *
+     * description: When enabled, redirect URIs can contain wildcard patterns (using `*`) in the
+     * hostname and pathname. Wildcards are not allowed in scheme, port, query, or hash. When
+     * wildcards are used in hostname, at least one dot is required to prevent overly broad patterns.
+     *
+     * example: Valid wildcard patterns
+     * ```js
+     * // Valid patterns:
+     * 'https://*.example.com/callback'
+     * 'https://app-*.preview.example.com/auth'
+     * 'https://example.com/*/callback'
+     *
+     * // Invalid patterns (wildcards not allowed in these locations):
+     * '*://example.com/callback'        // scheme
+     * 'https://example.com:*/callback'  // port
+     * 'https://example.com?code=*'      // query
+     * ```
+     */
+    allowWildcardRedirectUris: false,
+
+    /*
      * acceptQueryParamAccessTokens
      *
      * description: Several OAuth 2.0 / OIDC profiles prohibit the use of query strings to carry

--- a/lib/models/client.js
+++ b/lib/models/client.js
@@ -48,6 +48,153 @@ function URLparse(url) {
   }
 }
 
+const escapeRegExp = (value) => value.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
+
+const getEffectivePort = (protocol, port) => {
+  if (port) {
+    return port;
+  }
+
+  switch (protocol) {
+    case 'http:':
+      return '80';
+    case 'https:':
+      return '443';
+    default:
+      return '';
+  }
+};
+
+const matchHostnameWithWildcards = (patternHostname, actualHostname) => {
+  const pattern = String(patternHostname).toLowerCase();
+  const actual = String(actualHostname).toLowerCase();
+
+  if (!pattern.includes('*')) {
+    return pattern === actual;
+  }
+
+  const patternLabels = pattern.split('.');
+  const actualLabels = actual.split('.');
+
+  if (patternLabels.length !== actualLabels.length) {
+    return false;
+  }
+
+  return patternLabels.every((labelPattern, index) => {
+    const label = actualLabels[index] ?? '';
+
+    if (!labelPattern.includes('*')) {
+      return labelPattern === label;
+    }
+
+    const regex = new RegExp(
+      `^${labelPattern.split('*').map(escapeRegExp).join('[^.]+')}$`,
+      'i',
+    );
+    return regex.test(label);
+  });
+};
+
+const matchPathWithWildcards = (patternPathname, actualPathname) => {
+  if (!patternPathname.includes('*')) {
+    return patternPathname === actualPathname;
+  }
+
+  const regex = new RegExp(`^${patternPathname.split('*').map(escapeRegExp).join('.*')}$`);
+  return regex.test(actualPathname);
+};
+
+const parseWildcardUrlPattern = (pattern) => {
+  const schemeSeparatorIndex = pattern.indexOf('://');
+  if (schemeSeparatorIndex <= 0) {
+    return null;
+  }
+
+  // Disallow wildcards in scheme.
+  if (pattern.slice(0, schemeSeparatorIndex).includes('*')) {
+    return null;
+  }
+
+  // Disallow wildcards in query/hash (matching stays deterministic and safer).
+  const queryIndex = pattern.indexOf('?');
+  if (queryIndex >= 0 && pattern.slice(queryIndex).includes('*')) {
+    return null;
+  }
+
+  const hashIndex = pattern.indexOf('#');
+  if (hashIndex >= 0 && pattern.slice(hashIndex).includes('*')) {
+    return null;
+  }
+
+  const parsed = URLparse(pattern.replace(/\*/g, 'wildcard'));
+  if (!parsed) {
+    return null;
+  }
+
+  const rest = pattern.slice(schemeSeparatorIndex + 3);
+  const authority = rest.split(/[/?#]/)[0] ?? '';
+  if (!authority || authority.includes('@') || authority.startsWith('[')) {
+    return null;
+  }
+
+  const lastColonIndex = authority.lastIndexOf(':');
+  const hasPort = lastColonIndex > -1 && authority.indexOf(':') === lastColonIndex;
+  if (hasPort && authority.slice(lastColonIndex + 1).includes('*')) {
+    return null;
+  }
+
+  const hostnamePattern = hasPort ? authority.slice(0, lastColonIndex) : authority;
+
+  // When wildcard is used in hostname, require at least one dot to avoid overly broad patterns.
+  if (hostnamePattern.includes('*') && !hostnamePattern.includes('.')) {
+    return null;
+  }
+
+  const pathStartIndex = schemeSeparatorIndex + 3 + authority.length;
+  const pathEndIndex = Math.min(
+    ...[pattern.length, queryIndex >= 0 ? queryIndex : pattern.length, hashIndex >= 0 ? hashIndex : pattern.length],
+  );
+
+  const pathnamePattern = pattern.slice(pathStartIndex, pathEndIndex) || '/';
+
+  return {
+    protocol: parsed.protocol,
+    port: parsed.port,
+    hostnamePattern,
+    pathnamePattern,
+    search: parsed.search,
+    hash: parsed.hash,
+  };
+};
+
+const wildcardUrlMatch = (pattern, actual) => {
+  const parsedPattern = parseWildcardUrlPattern(pattern);
+  if (!parsedPattern) {
+    return false;
+  }
+
+  if (actual.protocol !== parsedPattern.protocol) {
+    return false;
+  }
+
+  if (
+    getEffectivePort(actual.protocol, actual.port)
+    !== getEffectivePort(parsedPattern.protocol, parsedPattern.port)
+  ) {
+    return false;
+  }
+
+  if (!matchHostnameWithWildcards(parsedPattern.hostnamePattern, actual.hostname)) {
+    return false;
+  }
+
+  if (!matchPathWithWildcards(parsedPattern.pathnamePattern, actual.pathname)) {
+    return false;
+  }
+
+  return actual.search === parsedPattern.search && actual.hash === parsedPattern.hash;
+};
+
 const validateJWKS = (jwks) => {
   if (jwks !== undefined) {
     if (!Array.isArray(jwks?.keys) || !jwks.keys.every(isPlainObject)) {
@@ -515,7 +662,11 @@ export default function getClient(provider) {
       const parsed = URLparse(value);
       if (!parsed) return false;
 
-      const match = this.redirectUris.find((allowed) => URLparse(allowed)?.href === parsed.href);
+      const match = this.redirectUris.find((allowed) => (
+        allowed.includes('*')
+          ? wildcardUrlMatch(allowed, parsed)
+          : URLparse(allowed)?.href === parsed.href
+      ));
       if (
         !!match
         || this.applicationType !== 'native'
@@ -551,8 +702,11 @@ export default function getClient(provider) {
     postLogoutRedirectUriAllowed(value) {
       const parsed = URLparse(value);
       if (!parsed) return false;
-      return !!this.postLogoutRedirectUris
-        .find((allowed) => URLparse(allowed)?.href === parsed.href);
+      return !!this.postLogoutRedirectUris.find((allowed) => (
+        allowed.includes('*')
+          ? wildcardUrlMatch(allowed, parsed)
+          : URLparse(allowed)?.href === parsed.href
+      ));
     }
 
     static async validate(metadata) {

--- a/lib/models/client.js
+++ b/lib/models/client.js
@@ -150,6 +150,13 @@ const parseWildcardUrlPattern = (pattern) => {
     return null;
   }
 
+  // Disallow wildcards in TLD position - the last two labels must not contain wildcards.
+  // This prevents overly broad patterns like `*.com` or `example.*`.
+  const hostnameLabels = hostnamePattern.split('.');
+  if (hostnameLabels.slice(-2).some((label) => label.includes('*'))) {
+    return null;
+  }
+
   const pathStartIndex = schemeSeparatorIndex + 3 + authority.length;
   const pathEndIndex = Math.min(
     ...[pattern.length, queryIndex >= 0 ? queryIndex : pattern.length, hashIndex >= 0 ? hashIndex : pattern.length],

--- a/lib/models/client.js
+++ b/lib/models/client.js
@@ -662,8 +662,9 @@ export default function getClient(provider) {
       const parsed = URLparse(value);
       if (!parsed) return false;
 
+      const allowWildcards = instance(provider).configuration('allowWildcardRedirectUris');
       const match = this.redirectUris.find((allowed) => (
-        allowed.includes('*')
+        allowWildcards && allowed.includes('*')
           ? wildcardUrlMatch(allowed, parsed)
           : URLparse(allowed)?.href === parsed.href
       ));
@@ -702,8 +703,9 @@ export default function getClient(provider) {
     postLogoutRedirectUriAllowed(value) {
       const parsed = URLparse(value);
       if (!parsed) return false;
+      const allowWildcards = instance(provider).configuration('allowWildcardRedirectUris');
       return !!this.postLogoutRedirectUris.find((allowed) => (
-        allowed.includes('*')
+        allowWildcards && allowed.includes('*')
           ? wildcardUrlMatch(allowed, parsed)
           : URLparse(allowed)?.href === parsed.href
       ));


### PR DESCRIPTION
## Summary

This PR adds support for wildcard matching in redirect URIs and post-logout redirect URIs, enabling dynamic environment support (such as preview deployments) while maintaining security constraints.

### Configuration

Wildcard support is **disabled by default**. To enable it:

```js
new Provider('http://localhost:3000', {
  allowWildcardRedirectUris: true,
});
```

### Changes

- Add `allowWildcardRedirectUris` configuration option (default: `false`)
- Add wildcard URL matching functions (`matchHostnameWithWildcards`, `matchPathWithWildcards`, `parseWildcardUrlPattern`, `wildcardUrlMatch`)
- Update `redirectUriAllowed()` to support wildcard patterns when enabled
- Update `postLogoutRedirectUriAllowed()` to support wildcard patterns when enabled
- Prevent automatic redirect URI assignment when wildcards are enabled and a wildcard pattern is used

### Security Constraints

Wildcards are restricted to ensure security:
- **Not allowed in**: scheme, port, query string, or hash
- **Hostname wildcards**: require at least one dot to prevent overly broad patterns (e.g., `*` alone is rejected, but `*.example.com` is allowed)
- **Explicit provision required**: wildcard redirect URIs must always be explicitly provided in requests

### Example Patterns

Valid patterns:
- `https://*.example.com/callback`
- `https://app-*.preview.example.com/auth`
- `https://example.com/*/callback`

Invalid patterns:
- `*://example.com/callback` (wildcard in scheme)
- `https://example.com:*/callback` (wildcard in port)
- `https://example.com/callback?code=*` (wildcard in query)

## Related

This change is required for the wildcard redirect URI feature in logto-io/logto#8094.