### PR TITLE
fix: escape `*/` sequences in block comments

### DIFF
--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -806,15 +806,15 @@ function makeDefaults() {
      * // Valid patterns:
      * 'https://*.example.com/callback'
      * 'https://app-*.preview.example.com/auth'
-     * 'https://example.com/*/callback'
+     * 'https://example.com/<*>/callback'
      *
      * // Invalid patterns (wildcards not allowed in these locations):
      * '*://example.com/callback'        // scheme
-     * 'https://example.com:*/callback'  // port
+     * 'https://example.com:<*>/callback'  // port
      * 'https://example.com?code=*'      // query
      * 'https://example.com/callback#*'  // hash
      * 'https://*.com/callback'          // top-level domain
-     * 'https://example.*/callback'      // top-level domain
+     * 'https://example.<*>/callback'      // top-level domain
      * ```
      */
     allowWildcardRedirectUris: false,


### PR DESCRIPTION
## Summary
The `*/` character sequence in JSDoc block comments prematurely terminates the comment, causing JavaScript syntax errors.

Example of the issue:
```js
/*
 * 'https://example.com/*/callback'  // The */ here ends the comment!
 */
```

This causes:
```
SyntaxError: Invalid or unexpected token
```

## Fix
Replace `*/` patterns in example URLs with `<*>/` to avoid premature comment termination while keeping the documentation clear.

## Test
```bash
node --check lib/helpers/defaults.js
```
