### PR TITLE
chore: set up CI guards and PATCHES.md skeleton for the v9 branch

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   run:
-    if: ${{ github.repository == 'panva/node-oidc-provider' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'logto-io/node-oidc-provider' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
       pull-requests: write
       discussions: write
-    if: ${{ github.repository == 'panva/node-oidc-provider' }}
+    if: ${{ github.repository == 'logto-io/node-oidc-provider' }}
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   npm:
-    if: ${{ github.repository == 'panva/node-oidc-provider' }}
+    if: ${{ github.repository == 'logto-io/node-oidc-provider' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,20 +5,20 @@ permissions:
 
 on:
   push:
-    branches: [main]
+    branches: [main, v9]
   pull_request:
-    branches: [main]
+    branches: [main, v9]
   schedule:
     - cron: '55 11 * * 1'
   workflow_dispatch:
 
 jobs:
   audit:
-    if: ${{ github.repository == 'panva/node-oidc-provider' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'logto-io/node-oidc-provider' || github.event_name == 'workflow_dispatch' }}
     uses: panva/.github/.github/workflows/npm-audit.yml@main
 
   node-versions:
-    if: ${{ github.repository == 'panva/node-oidc-provider' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'logto-io/node-oidc-provider' || github.event_name == 'workflow_dispatch' }}
     uses: panva/.github/.github/workflows/node-versions.yml@main
     with:
       min: 22

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,0 +1,27 @@
+# Fork patches
+
+This branch (`v9`) tracks upstream [panva/node-oidc-provider](https://github.com/panva/node-oidc-provider) at the `v9.9.1` tag. Every deviation from that tag is documented here — one section per patch, added by the pull request that applies it. If a change is not in this file, it does not exist in the fork.
+
+Each patch records four things:
+
+- **What it does** — the behavior change, in one or two sentences.
+- **Why upstream does not cover it** — the upstream decision or missing extension point that makes the patch necessary.
+- **Files touched**
+- **What breaks if dropped** — the observable failure that tells us the patch is missing.
+
+## Repository scaffolding
+
+### CI repository guards
+
+- **What it does**: points the `github.repository == …` guards in the GitHub workflows at `logto-io/node-oidc-provider`, so the test, conformance, lock, and release jobs run in this fork instead of silently skipping. Also registers the `v9` branch in `test.yml`'s `push` and `pull_request` triggers, so the test suite runs for every PR targeting `v9`.
+- **Why upstream does not cover it**: the guards hardcode `panva/node-oidc-provider`, and upstream only triggers on `main`.
+- **Files touched**: `.github/workflows/conformance.yml`, `.github/workflows/lock.yml`, `.github/workflows/release.yml`, `.github/workflows/test.yml` (5 guards).
+- **What breaks if dropped**: CI never runs on fork branches, so regressions land unnoticed.
+
+## Library patches
+
+None applied yet. Planned, in application order:
+
+1. **Client-specific interaction UID** — carry over `interaction_cookie_handler.js` plus the small hunks in `#getInteraction` and `interactions.js`, so each client keeps its own interaction session cookie.
+2. **Redirect URI validation relaxation** — minimal re-application after a requirements analysis; upstream 9.8.1 already relaxed the native custom-scheme rule, so only the still-needed lines return.
+3. **`scope` always present in token, introspection, and userinfo-bearing responses** — three one-line hunks (`grant_common.js`, `introspection.js`, `jwt.js`) replacing upstream's `scope || undefined`.


### PR DESCRIPTION
## Summary

First PR into the `v9` branch. Before this PR, `v9` is byte-for-byte identical to the upstream `v9.9.1` tag; `main` keeps serving the v8 pin that Logto master depends on.

Two scaffolding changes:

- **CI repository guards**: flip the 5 `github.repository == 'panva/node-oidc-provider'` guards to `logto-io/node-oidc-provider` across `test.yml`, `conformance.yml`, `lock.yml`, and `release.yml`, so the workflow jobs run in this fork instead of silently skipping. Same change `main` already carries.
- **`PATCHES.md` skeleton**: the single inventory of every deviation from the upstream tag. Each upcoming patch PR adds its own section (what it does / why upstream does not cover it / files touched / what breaks if dropped), so the next upgrade starts from a checklist instead of archaeology.

## Testing

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKDEDcBY6QZA75KmFgHTVx