### PR TITLE
feat: support client-specific interaction UIDs in cookies

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -20,8 +20,14 @@ Each patch records four things:
 
 ## Library patches
 
-None applied yet. Planned, in application order:
+### Client-specific interaction UID — `LOGTO PATCH(client-specific-interaction-uid)`
 
-1. **Client-specific interaction UID** — carry over `interaction_cookie_handler.js` plus the small hunks in `#getInteraction` and `interactions.js`, so each client keeps its own interaction session cookie.
-2. **Redirect URI validation relaxation** — minimal re-application after a requirements analysis; upstream 9.8.1 already relaxed the native custom-scheme rule, so only the still-needed lines return.
-3. **`scope` always present in token, introspection, and userinfo-bearing responses** — three one-line hunks (`grant_common.js`, `introspection.js`, `jwt.js`) replacing upstream's `scope || undefined`.
+- **What it does**: turns the interaction cookie value into a JSON mapping of client IDs to interaction UIDs, so concurrent sign-ins from different clients each resolve their own interaction. The requesting client is identified by the `Logto-App-Id` header (requests sent by the Logto Experience UI) or the `app_id` query parameter; a plain-string cookie from before the patch keeps working through a `_legacy` key. The mapping is stored percent-encoded — raw JSON is not a valid RFC 6265 cookie-value and strict servers (hapi, for one) reject the whole request over it; both pre-encoding formats (plain UID and the v8 fork's raw JSON) remain readable.
+- **Why upstream does not cover it**: there is no upstream equivalent feature, and the resolution point is a private class method (`Provider.#getInteraction`), unreachable from outside the library.
+- **Files touched**: `lib/helpers/interaction_cookie_handler.js` (new), `lib/actions/authorization/interactions.js`, `lib/provider.js`; tests in `test/client_specific_interaction_uid/`.
+- **What breaks if dropped**: two applications signing in concurrently in the same browser overwrite each other's interaction cookie, and Logto Experience requests carrying `Logto-App-Id` resolve the wrong interaction or none at all.
+
+Planned next, in application order:
+
+1. **Redirect URI validation relaxation** — minimal re-application after a requirements analysis; upstream 9.8.1 already relaxed the native custom-scheme rule, so only the still-needed lines return.
+2. **`scope` always present in token, introspection, and userinfo-bearing responses** — three one-line hunks (`grant_common.js`, `introspection.js`, `jwt.js`) replacing upstream's `scope || undefined`.

--- a/lib/actions/authorization/interactions.js
+++ b/lib/actions/authorization/interactions.js
@@ -3,6 +3,7 @@ import camelCase from '../../helpers/_/camel_case.js';
 import * as errors from '../../helpers/errors.js';
 import instance from '../../helpers/weak_cache.js';
 import nanoid from '../../helpers/nanoid.js';
+import { setInteractionUid } from '../../helpers/interaction_cookie_handler.js';
 
 const errorMap = { ...errors };
 
@@ -123,9 +124,21 @@ export default async function interactions(resumeRouteName, ctx, next) {
 
   const destination = await interactionUrl(ctx, interactionSession);
 
-  ctx.cookies.set(
-    oidc.provider.cookieName('interaction'),
+  /**
+   * LOGTO PATCH(client-specific-interaction-uid): keep one interaction UID per client in the
+   * cookie, so concurrent sign-ins from different clients do not overwrite each other.
+   */
+  const cookieName = oidc.provider.cookieName('interaction');
+  const currentCookieValue = ctx.cookies.get(cookieName, cookieOptions);
+  const newCookieValue = setInteractionUid(
+    currentCookieValue,
+    ctx.oidc.client.clientId,
     uid,
+  );
+
+  ctx.cookies.set(
+    cookieName,
+    newCookieValue,
     {
       path: new URL(destination, ctx.oidc.issuer).pathname,
       ...cookieOptions,

--- a/lib/helpers/interaction_cookie_handler.js
+++ b/lib/helpers/interaction_cookie_handler.js
@@ -1,0 +1,66 @@
+/**
+ * LOGTO PATCH(client-specific-interaction-uid)
+ *
+ * Helper functions to manage client-specific interaction UIDs in a single cookie
+ */
+
+import isPlainObject from './_/is_plain_object.js';
+
+/**
+ * Parse the interaction cookie value into a client-to-uid mapping
+ * @param {string|undefined} cookieValue - The raw cookie value (percent-encoded JSON string)
+ * @returns {Object} Client ID to UID mapping
+ */
+function parseInteractionCookie(cookieValue) {
+  if (!cookieValue) {
+    return {};
+  }
+
+  /**
+   * The mapping is stored percent-encoded, because raw JSON is not a valid RFC 6265
+   * cookie-value and strict servers reject the whole request over it. Decoding is a
+   * no-op for the two legacy formats (raw JSON and plain UID) since neither contains
+   * a percent sign.
+   */
+  let raw = cookieValue;
+  try {
+    raw = decodeURIComponent(cookieValue);
+  } catch {}
+
+  try {
+    const parsed = JSON.parse(raw);
+    return isPlainObject(parsed) ? parsed : {};
+  } catch {
+    // If it's not JSON, treat as legacy single-value format
+    return { _legacy: cookieValue };
+  }
+}
+
+/**
+ * Get the interaction UID for a specific client
+ * @param {string|undefined} cookieValue - The raw cookie value
+ * @param {string|null} clientId - The client ID
+ * @returns {string|undefined} The interaction UID for this client
+ */
+export function getInteractionUid(cookieValue, clientId) {
+  const mapping = parseInteractionCookie(cookieValue);
+  return mapping[clientId] || mapping._legacy;
+}
+
+/**
+ * Set the interaction UID for a specific client
+ * @param {string|undefined} cookieValue - The current cookie value
+ * @param {string|null} clientId - The client ID
+ * @param {string} uid - The interaction UID
+ * @returns {string} The new cookie value (percent-encoded JSON string)
+ */
+export function setInteractionUid(cookieValue, clientId, uid) {
+  const mapping = parseInteractionCookie(cookieValue);
+
+  // Add the new mapping
+  mapping[clientId] = uid;
+  // Also set the legacy key for backward compatibility
+  mapping._legacy = uid;
+
+  return encodeURIComponent(JSON.stringify(mapping));
+}

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -19,6 +19,7 @@ import { SessionNotFound, OIDCProviderError } from './helpers/errors.js';
 import * as models from './models/index.js';
 import ServerChallenge from './helpers/challenge.js';
 import als from './helpers/als.js';
+import { getInteractionUid } from './helpers/interaction_cookie_handler.js';
 
 export class Provider extends Koa {
   #AccessToken;
@@ -394,16 +395,33 @@ export class Provider extends Koa {
 
   async #getInteraction(req, res) {
     const ctx = this.createContext(req, res);
-    const id = ctx.cookies.get(
+    const cookieValue = ctx.cookies.get(
       this.cookieName('interaction'),
       this.#int.configuration.cookies.short,
     );
-    if (!id) {
+    if (!cookieValue) {
       throw new SessionNotFound('interaction session id cookie not found');
     }
+
+    /**
+     * LOGTO PATCH(client-specific-interaction-uid): resolve this client's interaction UID from
+     * the cookie mapping. The client ID comes from the Logto-App-Id header (requests sent by
+     * the Logto Experience UI) or the app_id query parameter (OIDC requests and redirections).
+     */
+    const clientId = ctx.headers['logto-app-id'] || new URL(ctx.request.url, this.issuer).searchParams.get('app_id');
+    const id = getInteractionUid(cookieValue, clientId);
+
     const interaction = await this.Interaction.find(id);
     if (!interaction) {
       throw new SessionNotFound('interaction session not found');
+    }
+
+    /**
+     * LOGTO PATCH(client-specific-interaction-uid): reject cross-client access to an
+     * interaction; an absent client ID is exempted for backward compatibility.
+     */
+    if (clientId && interaction.params.client_id !== clientId) {
+      throw new SessionNotFound('interaction client_id mismatch');
     }
 
     if (interaction.session?.uid) {

--- a/test/client_specific_interaction_uid/client_specific_interaction_uid.config.js
+++ b/test/client_specific_interaction_uid/client_specific_interaction_uid.config.js
@@ -1,0 +1,20 @@
+import getConfig from '../default.config.js';
+
+const config = getConfig();
+
+export default {
+  config,
+  clients: [{
+    client_id: 'client',
+    client_secret: 'secret',
+    grant_types: ['authorization_code'],
+    response_types: ['code'],
+    redirect_uris: ['https://client.example.com/cb'],
+  }, {
+    client_id: 'client-2',
+    client_secret: 'secret',
+    grant_types: ['authorization_code'],
+    response_types: ['code'],
+    redirect_uris: ['https://client2.example.com/cb'],
+  }],
+};

--- a/test/client_specific_interaction_uid/client_specific_interaction_uid.test.js
+++ b/test/client_specific_interaction_uid/client_specific_interaction_uid.test.js
@@ -1,0 +1,132 @@
+import { strict as assert } from 'node:assert';
+
+import { expect } from 'chai';
+import { createSandbox } from 'sinon';
+
+import bootstrap from '../test_helper.js';
+import { getInteractionUid } from '../../lib/helpers/interaction_cookie_handler.js';
+
+const sinon = createSandbox();
+
+/**
+ * LOGTO PATCH(client-specific-interaction-uid): the interaction cookie holds a JSON mapping of
+ * client IDs to interaction UIDs instead of a single UID, so concurrent sign-ins from different
+ * clients can each resolve their own interaction. These tests fail loudly if the patch is lost.
+ */
+
+function getInteractionCookieValue(response) {
+  const header = response.headers['set-cookie'].find((value) => value.startsWith('_interaction='));
+  expect(header).to.exist;
+  return header.split(';')[0].slice('_interaction='.length);
+}
+
+function getInteractionCookieMapping(response) {
+  return JSON.parse(decodeURIComponent(getInteractionCookieValue(response)));
+}
+
+describe('client-specific interaction UIDs', () => {
+  before(bootstrap(import.meta.url));
+  afterEach(sinon.restore);
+
+  beforeEach(function () { return this.logout(); });
+
+  it('stores the interaction UID keyed by client ID in the interaction cookie', async function () {
+    const auth = new this.AuthorizationRequest({
+      response_type: 'code',
+      scope: 'openid',
+    });
+
+    const response = await this.agent.get('/auth').query(auth).expect(303);
+    const uid = response.headers.location.split('/interaction/')[1];
+
+    const mapping = getInteractionCookieMapping(response);
+    expect(mapping).to.deep.equal({ client: uid, _legacy: uid });
+  });
+
+  it('merges concurrent interactions from different clients into one cookie mapping', async function () {
+    const first = await this.agent.get('/auth')
+      .query(new this.AuthorizationRequest({ response_type: 'code', scope: 'openid' }))
+      .expect(303);
+    const uid1 = first.headers.location.split('/interaction/')[1];
+
+    /**
+     * The response scopes the cookie to its own interaction path; re-save it at the root path
+     * so the next authorization request sends it, the way a mounted deployment configures it.
+     */
+    this.agent._saveCookies.bind(this.agent)({
+      request: { url: this.provider.issuer },
+      headers: { 'set-cookie': [`_interaction=${getInteractionCookieValue(first)}; path=/; httponly`] },
+    });
+
+    const second = await this.agent.get('/auth')
+      .query(new this.AuthorizationRequest({ client_id: 'client-2', response_type: 'code', scope: 'openid' }))
+      .expect(303);
+    const uid2 = second.headers.location.split('/interaction/')[1];
+
+    const mapping = getInteractionCookieMapping(second);
+    expect(mapping).to.deep.equal({ client: uid1, 'client-2': uid2, _legacy: uid2 });
+  });
+
+  it('resolves the interaction for the client identified by the Logto-App-Id header', async function () {
+    const response = await this.agent.get('/auth')
+      .query(new this.AuthorizationRequest({ response_type: 'code', scope: 'openid' }))
+      .expect(303);
+
+    await this.agent.get(response.headers.location)
+      .set('Logto-App-Id', 'client')
+      .expect(200)
+      .expect(/Sign-in/);
+  });
+
+  it('resolves the interaction for the client identified by the app_id query parameter', async function () {
+    const response = await this.agent.get('/auth')
+      .query(new this.AuthorizationRequest({ response_type: 'code', scope: 'openid' }))
+      .expect(303);
+
+    await this.agent.get(response.headers.location)
+      .query({ app_id: 'client' })
+      .expect(200)
+      .expect(/Sign-in/);
+  });
+
+  it('rejects resolving the interaction on behalf of a different client', async function () {
+    const response = await this.agent.get('/auth')
+      .query(new this.AuthorizationRequest({ response_type: 'code', scope: 'openid' }))
+      .expect(303);
+
+    sinon.spy(this.provider, 'interactionDetails');
+
+    await this.agent.get(response.headers.location)
+      .set('Logto-App-Id', 'client-2')
+      .expect(400);
+
+    return assert.rejects(this.provider.interactionDetails.getCall(0).returnValue, (err) => {
+      expect(err.name).to.eql('SessionNotFound');
+      expect(err.error_description).to.eql('interaction client_id mismatch');
+      return true;
+    });
+  });
+
+  it('accepts a legacy plain-string cookie value', async function () {
+    const response = await this.agent.get('/auth')
+      .query(new this.AuthorizationRequest({ response_type: 'code', scope: 'openid' }))
+      .expect(303);
+    const uid = response.headers.location.split('/interaction/')[1];
+
+    this.agent._saveCookies.bind(this.agent)({
+      request: { url: this.provider.issuer },
+      headers: { 'set-cookie': [`_interaction=${uid}; path=${response.headers.location}; httponly`] },
+    });
+
+    await this.agent.get(response.headers.location)
+      .set('Logto-App-Id', 'client')
+      .expect(200)
+      .expect(/Sign-in/);
+  });
+
+  it('reads the raw-JSON cookie format written before the value was percent-encoded', () => {
+    const raw = JSON.stringify({ client: 'uid-a', _legacy: 'uid-b' });
+    expect(getInteractionUid(raw, 'client')).to.equal('uid-a');
+    expect(getInteractionUid(raw, 'other')).to.equal('uid-b');
+  });
+});

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -22,6 +22,7 @@ import nanoid from '../lib/helpers/nanoid.js';
 import epochTime from '../lib/helpers/epoch_time.js';
 import Provider from '../lib/index.js';
 import instance from '../lib/helpers/weak_cache.js';
+import { getInteractionUid } from '../lib/helpers/interaction_cookie_handler.js';
 
 import { Account, TestAdapter } from './models.js';
 import keys from './keys.js';
@@ -315,9 +316,12 @@ export default function testHelper(importMetaUrl, {
             expect(query).to.be.null;
             expect(response).to.have.nested.property('headers.set-cookie').that.is.an('array');
 
-            const uid = readCookie(getSetCookies(response)[0]);
-            expect(readCookie(getSetCookies(response)[0]))
-              .to.equal(readCookie(getSetCookies(response)[1]));
+            /**
+             * LOGTO PATCH(client-specific-interaction-uid): the interaction cookie holds a JSON
+             * mapping of client IDs to UIDs, while the resume cookie still holds the plain UID.
+             */
+            const uid = getInteractionUid(readCookie(getSetCookies(response)[0]), this.client_id);
+            expect(uid).to.equal(readCookie(getSetCookies(response)[1]));
 
             const interaction = TestAdapter.for('Interaction').syncFind(uid);
 
@@ -340,7 +344,11 @@ export default function testHelper(importMetaUrl, {
 
     AuthorizationRequest.prototype.validateInteraction = (eName, ...eReasons) => {
       return (response) => {
-        const uid = readCookie(getSetCookies(response)[0]);
+        /**
+         * LOGTO PATCH(client-specific-interaction-uid): resolve the UID through the cookie
+         * mapping's backward-compatibility key.
+         */
+        const uid = getInteractionUid(readCookie(getSetCookies(response)[0]), null);
         const { prompt: { name, reasons } } = TestAdapter.for('Interaction').syncFind(uid);
         expect(name).to.equal(eName);
         expect(reasons).to.contain.members(eReasons);


### PR DESCRIPTION
## Summary

Re-applies the client-specific interaction UID patch (originally #15 on `main`) onto the `v9` branch. This is the one fork patch with no upstream equivalent and no external hook: v9 turned the resolution point into a private class method (`Provider.#getInteraction`), so it has to live in the fork.

**What the patch does**: the interaction cookie holds a JSON mapping of client IDs to interaction UIDs instead of a single UID, so concurrent sign-ins from different clients each resolve their own interaction. The requesting client is identified by the `Logto-App-Id` header (Logto Experience UI requests) or the `app_id` query parameter, with a `_legacy` key as the backward-compatibility fallback. Production-critical for Logto: Experience sends `Logto-App-Id` on every request, and this is what gives each application its own sign-in session.

Two deliberate deviations from the v8 patch:

- **The cookie value is now percent-encoded.** Raw JSON is not a valid RFC 6265 cookie-value (`"` and `,` are outside the allowed charset). Node, Koa, and Express tolerate it, but strict servers reject the whole request — the fork's own hapi-mounted test variant fails with `Invalid cookie value` (400) on every request carrying the cookie. Both pre-encoding formats (plain UID and v8's raw JSON) remain readable, because neither contains a percent sign, so decoding is a no-op for them and rolling upgrades are safe.
- **The missing-cookie error message stays upstream's** (`interaction session id cookie not found`); the v8 patch had changed it incidentally, which would have needlessly failed upstream's own test for it.

Also carried over: `LOGTO PATCH(client-specific-interaction-uid)` markers at every hunk, the PATCHES.md entry, and two small assertions in `test/test_helper.js` that read the interaction cookie through the new mapping (the only upstream test change needed; every other upstream test file is untouched).

The v8 patch had no tests; `test/client_specific_interaction_uid/` adds seven, covering the mapping write, the concurrent-clients merge, resolution via header and via query parameter, cross-client rejection, and both legacy cookie formats.

## Design boundaries inherited from the v8 patch (unchanged on purpose)

Three behavioral trade-offs exist in the original patch and are preserved exactly, since this PR is a 1:1 port. Listed here so the review confirms them consciously instead of discovering them:

1. **The cross-client mismatch check is skipped when no client ID is supplied.** A request without `Logto-App-Id`/`app_id` resolves through `_legacy` and is not checked for ownership. This keeps pre-patch callers working; the cost is that an unidentified request can reach another application's interaction — same browser, same user, so the exposure is limited.
2. **`_legacy` points at the most recently started interaction.** Single-application flows behave exactly as before the patch. Under concurrency, callers that do not identify themselves still get last-writer-wins — the patch fixes concurrency only for callers that send a client ID.
3. **The resume cookie (`_interaction_resume`) remains a single plain UID.** Concurrent resumes can still overwrite each other in principle. The write-then-immediately-consume window makes this rare in practice (no known incident on v8 in production), and the resume request is a browser redirect that cannot carry a header, so changing it would be a redesign rather than a port.

Tightening any of these (for example, dropping the exemption now that Experience always sends the header, or turning the resume cookie into a mapping) is deliberately out of scope for this PR — each would be a behavior change needing its own discussion.

See also the [reviewer notes comment](https://github.com/logto-io/node-oidc-provider/pull/26#issuecomment-4956431409) covering rollback compatibility, adversarial client IDs, and cookie size.

## Testing

Full fork test matrix green locally on every variant (standalone + express/koa/hapi/fastify mounts to `/oidc`): 2531 passing each, `biome lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKDEDcBY6QZA75KmFgHTVx
