### PR TITLE
fix: always include scope in token, introspection, and JWT responses

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -27,7 +27,13 @@ Each patch records four things:
 - **Files touched**: `lib/helpers/interaction_cookie_handler.js` (new), `lib/actions/authorization/interactions.js`, `lib/provider.js`; tests in `test/client_specific_interaction_uid/`.
 - **What breaks if dropped**: two applications signing in concurrently in the same browser overwrite each other's interaction cookie, and Logto Experience requests carrying `Logto-App-Id` resolve the wrong interaction or none at all.
 
+### Scope always present — `LOGTO PATCH(scope-always-present)`
+
+- **What it does**: token endpoint responses, introspection responses, and JWT access token payloads always carry the token's `scope` verbatim, instead of upstream's conditional omission (`source.scope ? at.scope : (at.scope || undefined)` and `scope || undefined`). Observable difference: an access token whose scope is empty (or whose source token had none) still yields a `scope` member; `undefined` scopes still drop out of the JSON as before.
+- **Why upstream does not cover it**: RFC 6749 §5.1 only requires `scope` in the response when it differs from the request, and upstream has omitted falsy scopes since the v8.4.0 RAR refactor (`e9fb5735`). Logto clients rely on `scope` always being echoed. This re-applies the v8 fork patches `4b621adf` and `de2d8fd6`.
+- **Files touched**: `lib/helpers/grant_common.js` (`buildTokenResponse`, shared by the authorization_code, ciba, device_code, and refresh_token grants), `lib/actions/grants/client_credentials.js`, `lib/actions/introspection.js`, `lib/models/formats/jwt.js`; tests in `test/scope_always_present/`. One hunk more than originally planned: `client_credentials` builds its response body without `buildTokenResponse`, so it carries its own hunk (behaviorally inert in v9 — its token scope is never an empty string — but kept so every response site shares the same invariant).
+- **What breaks if dropped**: responses for empty-scope tokens lose the `scope` member and `test/scope_always_present/` fails.
+
 Planned next, in application order:
 
 1. **Redirect URI validation relaxation** — minimal re-application after a requirements analysis; upstream 9.8.1 already relaxed the native custom-scheme rule, so only the still-needed lines return.
-2. **`scope` always present in token, introspection, and userinfo-bearing responses** — three one-line hunks (`grant_common.js`, `introspection.js`, `jwt.js`) replacing upstream's `scope || undefined`.

--- a/lib/actions/grants/client_credentials.js
+++ b/lib/actions/grants/client_credentials.js
@@ -70,7 +70,13 @@ export const handler = async function clientCredentialsHandler(ctx) {
     access_token: value,
     expires_in: token.expiration,
     token_type: token.tokenType,
-    scope: token.scope || undefined,
+    /**
+     * LOGTO PATCH(scope-always-present): always echo the token's scope in the token response.
+     * Upstream drops falsy scopes, but Logto clients rely on `scope` being present.
+     *
+     * Upstream: scope: token.scope || undefined,
+     */
+    scope: token.scope,
   };
 };
 

--- a/lib/actions/introspection.js
+++ b/lib/actions/introspection.js
@@ -147,7 +147,14 @@ export default function introspectionAction(provider) {
         aud: token.aud,
         authorization_details: token.rar
           ? await richAuthorizationRequests.rarForIntrospectionResponse(ctx, token) : undefined,
-        scope: token.scope || undefined,
+        /**
+         * LOGTO PATCH(scope-always-present): always include the token's scope in the
+         * introspection response. Upstream drops falsy scopes, but Logto clients rely on
+         * `scope` being present.
+         *
+         * Upstream: scope: token.scope || undefined,
+         */
+        scope: token.scope,
         cnf: token.isSenderConstrained() ? {} : undefined,
         token_type: token.kind !== 'RefreshToken' ? token.tokenType : undefined,
       });

--- a/lib/helpers/grant_common.js
+++ b/lib/helpers/grant_common.js
@@ -198,15 +198,26 @@ export async function issueIdToken(ctx, source, at, grant, {
   return token.issue({ use: 'idtoken' });
 }
 
+/**
+ * LOGTO PATCH(scope-always-present): callers still pass `source`, but this function no longer
+ * destructures it — the upstream conditional it fed is replaced below.
+ */
 export function buildTokenResponse(at, accessToken, {
-  idToken, refreshToken, source, rar,
+  idToken, refreshToken, rar,
 }) {
   return {
     access_token: accessToken,
     expires_in: at.expiration,
     id_token: idToken,
     refresh_token: refreshToken,
-    scope: source.scope ? at.scope : (at.scope || undefined),
+    /**
+     * LOGTO PATCH(scope-always-present): always echo the access token's scope in the token
+     * response. Upstream omits it when the source token carries no scope, but Logto clients
+     * rely on `scope` being present.
+     *
+     * Upstream: scope: source.scope ? at.scope : (at.scope || undefined),
+     */
+    scope: at.scope,
     token_type: at.tokenType,
     authorization_details: rar,
   };

--- a/lib/models/formats/jwt.js
+++ b/lib/models/formats/jwt.js
@@ -118,7 +118,14 @@ export default (provider, { opaque }) => {
         iat,
         exp,
         authorization_details: rar,
-        scope: scope || undefined,
+        /**
+         * LOGTO PATCH(scope-always-present): always include the scope claim in the JWT access
+         * token payload. Upstream drops falsy scopes, but Logto clients rely on `scope` being
+         * present.
+         *
+         * Upstream: scope: scope || undefined,
+         */
+        scope,
         client_id: clientId,
         iss: provider.issuer,
         aud,

--- a/test/scope_always_present/scope_always_present.config.js
+++ b/test/scope_always_present/scope_always_present.config.js
@@ -1,0 +1,18 @@
+import merge from 'lodash/merge.js';
+
+import getConfig from '../default.config.js';
+
+const config = getConfig();
+
+merge(config.features, {
+  introspection: { enabled: true },
+});
+
+export default {
+  config,
+  clients: [{
+    client_id: 'client',
+    client_secret: 'secret',
+    redirect_uris: ['https://client.example.com/cb'],
+  }],
+};

--- a/test/scope_always_present/scope_always_present.test.js
+++ b/test/scope_always_present/scope_always_present.test.js
@@ -1,0 +1,70 @@
+import { expect } from 'chai';
+import base64url from 'base64url';
+
+import bootstrap from '../test_helper.js';
+import { buildTokenResponse } from '../../lib/helpers/grant_common.js';
+import ResourceServer from '../../lib/helpers/resource_server.js';
+
+/**
+ * LOGTO PATCH(scope-always-present): token, introspection, and JWT access token payloads carry
+ * the `scope` property whenever the token has one, including the empty string upstream would
+ * omit. These tests fail loudly if the patch is lost.
+ */
+
+function decodePayload(jwt) {
+  return JSON.parse(base64url.decode(jwt.split('.')[1]));
+}
+
+describe('scope always present', () => {
+  before(bootstrap(import.meta.url));
+  before(function () { return this.login({ accountId: 'accountId' }); });
+
+  describe('token endpoint response', () => {
+    it('keeps the access token scope even when the source token has none', () => {
+      const at = { expiration: 3600, tokenType: 'Bearer', scope: '' };
+      const response = buildTokenResponse(at, 'token-value', { source: {} });
+
+      expect(response).to.have.property('scope', '');
+    });
+  });
+
+  describe('introspection response', () => {
+    it('includes an empty scope', async function () {
+      const at = new this.provider.AccessToken({
+        accountId: 'accountId',
+        grantId: this.getGrantId(),
+        client: await this.provider.Client.find('client'),
+        scope: '',
+      });
+
+      const token = await at.save();
+      return this.agent.post('/token/introspection')
+        .auth('client', 'secret')
+        .send({ token })
+        .type('form')
+        .expect(200)
+        .expect((response) => {
+          expect(response.body).to.have.property('scope', '');
+        });
+    });
+  });
+
+  describe('jwt access token payload', () => {
+    it('includes an empty scope claim', async function () {
+      const at = new this.provider.AccessToken({
+        accountId: 'accountId',
+        grantId: this.getGrantId(),
+        client: await this.provider.Client.find('client'),
+        scope: '',
+        resourceServer: new ResourceServer('urn:example:rs', {
+          accessTokenFormat: 'jwt',
+          audience: 'urn:example:rs',
+        }),
+      });
+
+      const token = await at.save();
+
+      expect(decodePayload(token)).to.have.property('scope', '');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Re-applies the scope-always-present patches (originally #3 and #4 on `main`, commits `4b621adf` and `de2d8fd6`) onto the `v9` branch, as planned in PATCHES.md. Token endpoint responses, introspection responses, and JWT access token payloads now always carry the token's `scope` verbatim, replacing upstream's conditional omission.

**Why the fork needs it**: RFC 6749 §5.1 only requires `scope` in the token response when it differs from the request, and upstream has omitted falsy scopes since the v8.4.0 RAR refactor (`e9fb5735`). Logto clients rely on `scope` always being echoed. The observable difference is for empty-string scopes (and sources without one): upstream drops the member, the fork keeps `"scope": ""`. Tokens whose scope is `undefined` still serialize without the member, exactly as before — `JSON.stringify` drops `undefined` values — so this changes nothing for scope-less client_credentials exchanges.

**Four hunks instead of the three planned in PATCHES.md.** The v8 patch touched five grant files plus introspection and the JWT format; in v9 four of those grants share `buildTokenResponse()` in `lib/helpers/grant_common.js`, which is where the main hunk lands. But `client_credentials` builds its response body without that helper, so it carries its own hunk — behaviorally inert in v9 (its token scope is never an empty string, always `join(' ') || undefined` at creation) but kept so every response site shares the same invariant and a future upstream change cannot silently reintroduce the omission there. PATCHES.md documents this deviation.

One consequence inside `buildTokenResponse`: the upstream conditional was the only consumer of the `source` parameter, so the patched signature no longer destructures it (callers still pass it, which keeps their hunks nonexistent — every upstream call site is untouched). A `LOGTO PATCH(scope-always-present)` marker sits at each hunk, following the fork convention.

**Tests**: the v8 patches had none; `test/scope_always_present/` adds three guards, one per response surface — `buildTokenResponse` with an empty-scope access token, an introspection round-trip of a stored empty-scope token, and a decoded JWT access token payload. All three were verified to fail against unpatched `lib/` (stash-checked) and no upstream test file needed changes.

## Testing

Unit tests in `test/scope_always_present/`. Full fork test matrix green locally on every variant (standalone + express/koa/hapi/fastify mounts to `/oidc`): 2547 passing each, `biome lint` clean.

## Checklist

- [ ] `.changeset` — N/A (fork tracks upstream release tags; no changesets in this repo)
- [x] unit tests
- [ ] integration tests — N/A
- [ ] necessary TSDoc comments — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Aum6XeeRFUY6ZCS2EXXQq
