### PR TITLE
docs: finalize the PATCHES.md patch inventory

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -9,6 +9,8 @@ Each patch records four things:
 - **Files touched**
 - **What breaks if dropped** — the observable failure that tells us the patch is missing.
 
+To audit this inventory, run `git diff v9.9.1 --stat` on the branch: every file in that diff must appear in a **Files touched** list below (or be this file). The next upstream upgrade starts from that command and this document — re-apply each section onto the new tag, or retire it with a note here.
+
 ## Repository scaffolding
 
 ### CI repository guards
@@ -24,7 +26,7 @@ Each patch records four things:
 
 - **What it does**: turns the interaction cookie value into a JSON mapping of client IDs to interaction UIDs, so concurrent sign-ins from different clients each resolve their own interaction. The requesting client is identified by the `Logto-App-Id` header (requests sent by the Logto Experience UI) or the `app_id` query parameter; a plain-string cookie from before the patch keeps working through a `_legacy` key. The mapping is stored percent-encoded — raw JSON is not a valid RFC 6265 cookie-value and strict servers (hapi, for one) reject the whole request over it; both pre-encoding formats (plain UID and the v8 fork's raw JSON) remain readable.
 - **Why upstream does not cover it**: there is no upstream equivalent feature, and the resolution point is a private class method (`Provider.#getInteraction`), unreachable from outside the library.
-- **Files touched**: `lib/helpers/interaction_cookie_handler.js` (new), `lib/actions/authorization/interactions.js`, `lib/provider.js`; tests in `test/client_specific_interaction_uid/`.
+- **Files touched**: `lib/helpers/interaction_cookie_handler.js` (new), `lib/actions/authorization/interactions.js`, `lib/provider.js`; tests in `test/client_specific_interaction_uid/`, plus two hunks in the shared harness `test/test_helper.js` (the interaction cookie now holds the mapping, so the harness resolves UIDs through `getInteractionUid`).
 - **What breaks if dropped**: two applications signing in concurrently in the same browser overwrite each other's interaction cookie, and Logto Experience requests carrying `Logto-App-Id` resolve the wrong interaction or none at all.
 
 ### Scope always present — `LOGTO PATCH(scope-always-present)`


### PR DESCRIPTION
Closes LOG-13810. Final PR of the fork-side v9 work: `PATCHES.md` is now the complete inventory of every deviation from the upstream `v9.9.1` tag, and the full upstream suite is verified green on `v9` with all patches applied — the gate that unblocks the dependency flip (LOG-13811).

## What changes

- Adds `test/test_helper.js` to the client-specific interaction UID patch's **Files touched** — the two shared-harness hunks (UID resolution through `getInteractionUid`) were applied by #26 but never recorded.
- Adds a self-audit note to the intro: `git diff v9.9.1 --stat` must be fully covered by the **Files touched** lists below, and the next upstream upgrade starts from that command plus this document.

## Inventory audit

Compared `git diff v9.9.1..v9 --stat` (20 files) against the document — every file is accounted for:

- 4 workflow files → CI repository guards (#25)
- `lib/helpers/interaction_cookie_handler.js` (new), `lib/actions/authorization/interactions.js`, `lib/provider.js`, `test/client_specific_interaction_uid/`, `test/test_helper.js` → client-specific interaction UID (#26)
- `lib/helpers/grant_common.js`, `lib/actions/grants/client_credentials.js`, `lib/actions/introspection.js`, `lib/models/formats/jwt.js`, `test/scope_always_present/` → scope always present (#27)
- `lib/helpers/client_schema.js`, `test/configuration/client_metadata.test.js`, `test/oauth_native_apps/oauth_native_apps.test.js` → redirect URI relaxation (#28)

Library footprint: 8 files under `lib/`, +154/−46 lines against the tag (net +108, including the 66-line new cookie-handler helper and the `LOGTO PATCH(...)` comments) — in the ballpark of the ~90-line target once comments are discounted, and down from ~330 on the v8 fork. The wildcard redirect URI patch stays out by design: its matching logic moves into Logto core (LOG-13813).

## Testing

Full `npm run test-ci` locally: all 5 passes green (bare + express/koa/hapi/fastify mounts at `/oidc`), 2547 passing / 5 pending each; `biome lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDLArmqeNx5jVea2DmKcra
