### PR TITLE
test: cover DPoP proof replay detection at the token endpoint

### DIFF
--- a/test/dpop_token_endpoint_replay/dpop_token_endpoint_replay.config.js
+++ b/test/dpop_token_endpoint_replay/dpop_token_endpoint_replay.config.js
@@ -1,0 +1,21 @@
+import merge from 'lodash/merge.js';
+
+import getConfig from '../default.config.js';
+
+const config = getConfig();
+
+merge(config.features, {
+  dPoP: { enabled: true },
+  clientCredentials: { enabled: true },
+});
+
+export default {
+  config,
+  clients: [{
+    client_id: 'client',
+    client_secret: 'secret',
+    grant_types: ['authorization_code', 'refresh_token', 'client_credentials'],
+    response_types: ['code'],
+    redirect_uris: ['https://client.example.com/cb'],
+  }],
+};

--- a/test/dpop_token_endpoint_replay/dpop_token_endpoint_replay.test.js
+++ b/test/dpop_token_endpoint_replay/dpop_token_endpoint_replay.test.js
@@ -1,0 +1,164 @@
+import * as url from 'node:url';
+
+import sinon from 'sinon';
+import { expect } from 'chai';
+import {
+  SignJWT, exportJWK, calculateJwkThumbprint, generateKeyPair,
+} from 'jose';
+
+import nanoid from '../../lib/helpers/nanoid.js';
+import bootstrap, { skipConsent } from '../test_helper.js';
+
+/**
+ * Replay detection of DPoP proofs at the token endpoint. The main dpop suite covers proof
+ * binding at the token endpoint and replay detection at the userinfo endpoint; these tests pin
+ * the token-endpoint replay branches — `applyDpopBinding` in `helpers/grant_common.js` (used by
+ * the client_credentials grant) and the inline check in `actions/grants/refresh_token.js` —
+ * along with the `features.dPoP.allowReplay` escape hatch.
+ */
+
+async function DPoP(keypair, htu, htm) {
+  return new SignJWT({ htu, htm })
+    .setProtectedHeader({ alg: 'ES256', typ: 'dpop+jwt', jwk: await exportJWK(keypair.publicKey) })
+    .setJti(nanoid())
+    .setIssuedAt()
+    .sign(keypair.privateKey);
+}
+
+describe('token endpoint DPoP proof replay detection', () => {
+  before(bootstrap(import.meta.url));
+  before(function () { return this.login({ scope: 'openid offline_access' }); });
+  skipConsent();
+  before(async function () {
+    this.keypair = await generateKeyPair('ES256', { extractable: true });
+    this.thumbprint = await calculateJwkThumbprint(await exportJWK(this.keypair.publicKey));
+  });
+
+  describe('client_credentials', () => {
+    it('rejects a proof that was already used', async function () {
+      const proof = await DPoP(this.keypair, `${this.provider.issuer}${this.suitePath('/token')}`, 'POST');
+
+      await this.agent.post('/token')
+        .auth('client', 'secret')
+        .send({ grant_type: 'client_credentials' })
+        .set('DPoP', proof)
+        .type('form')
+        .expect(200);
+
+      const spy = sinon.spy();
+      this.provider.once('grant.error', spy);
+
+      await this.agent.post('/token')
+        .auth('client', 'secret')
+        .send({ grant_type: 'client_credentials' })
+        .set('DPoP', proof)
+        .type('form')
+        .expect(400)
+        .expect({ error: 'invalid_grant', error_description: 'grant request is invalid' });
+
+      expect(spy).to.have.property('calledOnce', true);
+      expect(spy.args[0][1]).to.have.property('error_detail', 'DPoP proof JWT Replay detected');
+    });
+
+    describe('with features.dPoP.allowReplay enabled', () => {
+      before(function () {
+        this.orig = i(this.provider).features.dPoP.allowReplay;
+        i(this.provider).features.dPoP.allowReplay = true;
+      });
+
+      after(function () {
+        i(this.provider).features.dPoP.allowReplay = this.orig;
+      });
+
+      it('accepts a proof that was already used and still binds the token', async function () {
+        const proof = await DPoP(this.keypair, `${this.provider.issuer}${this.suitePath('/token')}`, 'POST');
+
+        await this.agent.post('/token')
+          .auth('client', 'secret')
+          .send({ grant_type: 'client_credentials' })
+          .set('DPoP', proof)
+          .type('form')
+          .expect(200);
+
+        const spy = sinon.spy();
+        this.provider.once('grant.success', spy);
+
+        await this.agent.post('/token')
+          .auth('client', 'secret')
+          .send({ grant_type: 'client_credentials' })
+          .set('DPoP', proof)
+          .type('form')
+          .expect(200);
+
+        expect(spy).to.have.property('calledOnce', true);
+        const { oidc: { entities: { ClientCredentials } } } = spy.args[0][0];
+        expect(ClientCredentials).to.have.property('jkt', this.thumbprint);
+      });
+    });
+  });
+
+  describe('refresh_token', () => {
+    beforeEach(async function () {
+      // biome-ignore lint/suspicious/noAssignInExpressions: test pattern
+      const auth = this.auth = new this.AuthorizationRequest({
+        response_type: 'code',
+        scope: 'openid offline_access',
+        prompt: 'consent',
+      });
+
+      await this.wrap({ route: '/auth', verb: 'get', auth })
+        .expect(303)
+        .expect(auth.validateClientLocation)
+        .expect(({ headers: { location } }) => {
+          const { query: { code } } = url.parse(location, true);
+          this.code = code;
+        });
+
+      await this.agent.post('/token')
+        .auth('client', 'secret')
+        .send({
+          grant_type: 'authorization_code',
+          code_verifier: this.auth.code_verifier,
+          code: this.code,
+          redirect_uri: 'https://client.example.com/cb',
+        })
+        .type('form')
+        .set('DPoP', await DPoP(this.keypair, `${this.provider.issuer}${this.suitePath('/token')}`, 'POST'))
+        .expect(200)
+        .expect(({ body }) => {
+          this.rt = body.refresh_token;
+        });
+    });
+
+    it('rejects a proof that was already used', async function () {
+      const proof = await DPoP(this.keypair, `${this.provider.issuer}${this.suitePath('/token')}`, 'POST');
+
+      await this.agent.post('/token')
+        .auth('client', 'secret')
+        .send({
+          grant_type: 'refresh_token',
+          refresh_token: this.rt,
+        })
+        .set('DPoP', proof)
+        .type('form')
+        .expect(200);
+
+      const spy = sinon.spy();
+      this.provider.once('grant.error', spy);
+
+      await this.agent.post('/token')
+        .auth('client', 'secret')
+        .send({
+          grant_type: 'refresh_token',
+          refresh_token: this.rt,
+        })
+        .set('DPoP', proof)
+        .type('form')
+        .expect(400)
+        .expect({ error: 'invalid_grant', error_description: 'grant request is invalid' });
+
+      expect(spy).to.have.property('calledOnce', true);
+      expect(spy.args[0][1]).to.have.property('error_detail', 'DPoP proof JWT Replay detected');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add a self-contained suite (`test/dpop_token_endpoint_replay/`) pinning the token-endpoint DPoP replay branches that the main `test/dpop` suite does not exercise. That suite covers proof **binding** at the token endpoint and **replay detection at the userinfo endpoint**, but no case reuses the same proof at the token endpoint, and `features.dPoP.allowReplay` has no coverage at all.

Three tests:

- `client_credentials`: reusing a proof is rejected with `invalid_grant` / `DPoP proof JWT Replay detected` — pins the replay branch of `applyDpopBinding` in `helpers/grant_common.js`.
- `client_credentials` with `allowReplay` enabled (toggled at runtime, same pattern as the main suite's `requireNonce` toggle): the reused proof is accepted and the token is still `jkt`-bound.
- `refresh_token`: reusing a proof is rejected — pins the separate inline replay check in `actions/grants/refresh_token.js`.

Context: the gap surfaced while reviewing logto-io/logto#9213, where Logto's grants finished delegating their DPoP handling to `applyDpopBinding` — after that, these branches are the only implementation of token-endpoint replay detection Logto relies on, so they get their regression guard here, in the library's own suite.

## Testing

- New suite passes; the full run is green (2553 passing).
- Mutation checks: disabling the replay check in `applyDpopBinding`, disabling the inline check in `refresh_token.js`, and ignoring `allowReplay` each fail exactly the one test that guards it.

## Checklist

- [x] `.changeset` — N/A in this repository
- [x] unit tests — this PR is test-only
- [x] integration tests — N/A
- [x] necessary TSDoc comments — file-level comment explains what the suite pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cXc449M4wpCQDaB1oYaoh